### PR TITLE
Fix CI and add redirects

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,0 +1,258 @@
+def main(ctx):
+    # Config
+
+    environment = "main-page"
+
+    # Version shown as latest in generated documentations
+    # It's fine that this is out of date in version branches, usually just needs
+    # adjustment in master/deployment_branch when a new version is added to site.yml
+    latest_version = "master"
+    default_branch = "master"
+
+    # Current version branch (used to determine when changes are supposed to be pushed)
+    # pushes to base_branch will trigger a build in deployment_branch but pushing
+    # to fix-typo branch won't
+    base_branch = latest_version
+
+    # Version branches never deploy themselves, but instead trigger a deployment in deployment_branch
+    # This must not be changed in version branches
+    deployment_branch = default_branch
+    pdf_branch = default_branch
+
+    return [
+        checkStarlark(),
+        build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_branch),
+        trigger(ctx, environment, latest_version, deployment_branch, base_branch, pdf_branch),
+    ]
+
+def checkStarlark():
+    return {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "check-starlark",
+        "steps": [
+            {
+                "name": "format-check-starlark",
+                "image": "owncloudci/bazel-buildifier",
+                "pull": "always",
+                "commands": [
+                    "buildifier --mode=check .drone.star",
+                ],
+            },
+            {
+                "name": "show-diff",
+                "image": "owncloudci/bazel-buildifier",
+                "pull": "always",
+                "commands": [
+                    "buildifier --mode=fix .drone.star",
+                    "git diff",
+                ],
+                "when": {
+                    "status": [
+                        "failure",
+                    ],
+                },
+            },
+        ],
+        "depends_on": [],
+        "trigger": {
+            "ref": [
+                "refs/pull/**",
+            ],
+        },
+    }
+
+def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_branch):
+    return {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "documentation",
+        "platform": {
+            "os": "linux",
+            "arch": "amd64",
+        },
+        "steps": [
+            {
+                "name": "cache-restore",
+                "pull": "always",
+                "image": "plugins/s3-cache:1",
+                "settings": {
+                    "endpoint": from_secret("cache_s3_server"),
+                    "access_key": from_secret("cache_s3_access_key"),
+                    "secret_key": from_secret("cache_s3_secret_key"),
+                    "restore": "true",
+                },
+            },
+            {
+                "name": "docs-deps",
+                "pull": "always",
+                "image": "owncloudci/nodejs:16",
+                "commands": [
+                    "yarn install",
+                ],
+            },
+            {
+                "name": "docs-validate",
+                "pull": "always",
+                "image": "owncloudci/nodejs:16",
+                "commands": [
+                    "yarn validate --fetch",
+                ],
+            },
+            {
+                "name": "docs-build",
+                "pull": "always",
+                "image": "owncloudci/nodejs:16",
+                "commands": [
+                    "yarn antora --fetch --attribute format=html",
+                ],
+            },
+            {
+                "name": "docs-pdf",
+                "pull": "always",
+                "image": "owncloudci/asciidoctor:latest",
+                "commands": [
+                    "bin/makepdf -m",
+                ],
+            },
+            {
+                "name": "cache-rebuild",
+                "pull": "always",
+                "image": "plugins/s3-cache:1",
+                "settings": {
+                    "endpoint": from_secret("cache_s3_server"),
+                    "access_key": from_secret("cache_s3_access_key"),
+                    "secret_key": from_secret("cache_s3_secret_key"),
+                    "rebuild": "true",
+                    "mount": [
+                        "node_modules",
+                    ],
+                },
+                "when": {
+                    "event": [
+                        "push",
+                        "cron",
+                    ],
+                    "branch": [
+                        deployment_branch,
+                        base_branch,
+                    ],
+                },
+            },
+            {
+                "name": "cache-flush",
+                "pull": "always",
+                "image": "plugins/s3-cache:1",
+                "settings": {
+                    "endpoint": from_secret("cache_s3_server"),
+                    "access_key": from_secret("cache_s3_access_key"),
+                    "secret_key": from_secret("cache_s3_secret_key"),
+                    "flush": "true",
+                    "flush_age": "14",
+                },
+                "when": {
+                    "event": [
+                        "push",
+                        "cron",
+                    ],
+                },
+            },
+            {
+                "name": "upload-pdf",
+                "pull": "always",
+                "image": "plugins/s3-sync",
+                "settings": {
+                    "bucket": "uploads",
+                    "endpoint": from_secret("docs_s3_server"),
+                    "access_key": from_secret("docs_s3_access_key"),
+                    "secret_key": from_secret("docs_s3_secret_key"),
+                    "path_style": "true",
+                    "source": "pdf_web/",
+                    "target": "/pdf/%s" % environment,
+                },
+                "when": {
+                    "event": [
+                        "push",
+                        "cron",
+                    ],
+                    "branch": [
+                        pdf_branch,
+                    ],
+                },
+            },
+            {
+                "name": "notify",
+                "pull": "if-not-exists",
+                "image": "plugins/slack",
+                "settings": {
+                    "webhook": from_secret("rocketchat_talk_webhook"),
+                    "channel": "documentation",
+                },
+                "when": {
+                    "event": [
+                        "push",
+                        "cron",
+                    ],
+                    "status": [
+                        "failure",
+                    ],
+                },
+            },
+        ],
+        "depends_on": [
+            "check-starlark",
+        ],
+        "trigger": {
+            "ref": {
+                "include": [
+                    "refs/heads/%s" % deployment_branch,
+                    "refs/heads/%s" % pdf_branch,
+                    "refs/tags/**",
+                    "refs/pull/**",
+                ],
+            },
+        },
+    }
+
+def trigger(ctx, environment, latest_version, deployment_branch, base_branch, pdf_branch):
+    return {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "trigger",
+        "platform": {
+            "os": "linux",
+            "arch": "amd64",
+        },
+        "clone": {
+            "disable": True,
+        },
+        "steps": [
+            {
+                "name": "trigger-docs",
+                "pull": "always",
+                "image": "plugins/downstream",
+                "settings": {
+                    "server": "https://drone.owncloud.com",
+                    "token": from_secret("drone_token"),
+                    "fork": "true",
+                    "repositories": [
+                        "owncloud/docs@master",
+                    ],
+                },
+            },
+        ],
+        "depends_on": [
+            "documentation",
+        ],
+        "trigger": {
+            "ref": [
+                "refs/heads/%s" % deployment_branch,
+                "refs/heads/%s" % base_branch,
+            ],
+        },
+    }
+
+def from_secret(name):
+    return {
+        "from_secret": name,
+    }

--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -1,6 +1,7 @@
 = ownCloud App and Client Releases
 :toc: right
 :toclevels: 3
+:page-aliases: next@docs::client_releases.adoc
 
 == Introduction
 

--- a/modules/ROOT/pages/how_to_contribute.adoc
+++ b/modules/ROOT/pages/how_to_contribute.adoc
@@ -1,5 +1,6 @@
 = How to Contribute to the ownCloud Documentation
 :toc: right
+:page-aliases: next@docs::how_to_contribute.adoc
 
 :asciidoc-syntax-url: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/
 :antora-platform-url: https://docs.antora.org/

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,7 @@
 = ownCloud Documentation Overview
 :toc: right
 :toclevels: 3
+:page-aliases: next@docs::index.adoc
 
 == What is Infinite Scale
 

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -2,6 +2,7 @@
 :toc: macro
 :toclevels: 2
 :toc-title: Releases
+:page-aliases: next@docs::ocis_release_notes.adoc
 
 :release-roadmap-url: https://github.com/owncloud/ocis/blob/master/docs/ocis/release_roadmap.md
 

--- a/modules/ROOT/pages/ocis_releases.adoc
+++ b/modules/ROOT/pages/ocis_releases.adoc
@@ -1,6 +1,7 @@
 = Infinite Scale Server Releases
 :toc: right
 :toclevels: 1
+:page-aliases: next@docs::ocis_releases.adoc
 
 :description: ownCloud provides in-depth documentation for Infinite Scale. Functionalities added or decommissioned dependent on a particular version are referenced in the documentation directly.
 

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -2,7 +2,8 @@
 :server-10_2-avatar-change-url: https://github.com/owncloud/core/issues/35311
 :owncloud-server-changelog-url: https://owncloud.com/changelog/server/
 :page-aliases: {latest-server-version}@server:admin_manual:whats_new_admin.adoc, \
-{latest-server-version}@server:ROOT:server_release_notes.adoc
+{latest-server-version}@server:ROOT:server_release_notes.adoc, \
+next@docs::server_release_notes.adoc
 
 * xref:changes-in-10-13-4[Changes in 10.13.4]
 * xref:changes-in-10-13-3[Changes in 10.13.3]

--- a/modules/ROOT/pages/server_releases.adoc
+++ b/modules/ROOT/pages/server_releases.adoc
@@ -1,7 +1,7 @@
 = ownCloud Server Releases
 :toc: right
 :toclevels: 3
-:page-aliases: releases.adoc
+:page-aliases: releases.adoc, next@docs::server_releases.adoc
 
 == Introduction
 


### PR DESCRIPTION
Finalizes #1 and https://github.com/owncloud/docs/pull/4921 which now adds CI (.drone.star) and redirects to all pages so they are available on the old link.

After merging this, I will update the branch protection rules to include CI and approvals.

@EParzefall @phil-davis fyi

