### PR TITLE
Make the landing page component and versionless

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,10 @@
-name: docs_main
+# this is the sites landing page
+# to make it component and version free in the URL, the 'name' MUST be ROOT and the 'version' ~
+# see the docs's site.yml to see how the start page it gets integrated.
+# see: https://docs.antora.org/antora/latest/component-name-key/#root-component
+name: ROOT
 title: ownCloud Main Page
-version: next
+version: ~
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/partials/nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
-# this is the sites landing page
+# this is the site's landing page
 # to make it component and version free in the URL, the 'name' MUST be ROOT and the 'version' ~
-# see the docs's site.yml to see how the start page it gets integrated.
+# see the docs's site.yml to see how the start page gets integrated.
 # see: https://docs.antora.org/antora/latest/component-name-key/#root-component
 name: ROOT
 title: ownCloud Main Page


### PR DESCRIPTION
This PR prepares to make the landing page of the site commponent and version less:

`doc.owncloud.com` will not longer redirect to `doc.owncloud.com/docs_main/next`

 This is a great improvement as robots.txt and site.yml will now work correctly in Google indexing.

Needs also a change in the docs repo which will come as second step.