### PR TITLE
Make a page-aliases for all pages

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -1,7 +1,7 @@
 = ownCloud App and Client Releases
 :toc: right
 :toclevels: 3
-:page-aliases: next@docs::client_releases.adoc
+:page-aliases: next@docs::client_releases.adoc, next@docs_main::client_releases.adoc
 
 == Introduction
 

--- a/modules/ROOT/pages/how_to_contribute.adoc
+++ b/modules/ROOT/pages/how_to_contribute.adoc
@@ -1,6 +1,6 @@
 = How to Contribute to the ownCloud Documentation
 :toc: right
-:page-aliases: next@docs::how_to_contribute.adoc
+:page-aliases: next@docs::how_to_contribute.adoc, next@docs_main::how_to_contribute.adoc
 
 :asciidoc-syntax-url: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/
 :antora-platform-url: https://docs.antora.org/

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = ownCloud Documentation Overview
 :toc: right
 :toclevels: 3
-:page-aliases: next@docs::index.adoc
+:page-aliases: next@docs::index.adoc, next@docs_main::index.adoc
 
 == What is Infinite Scale
 

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -2,7 +2,7 @@
 :toc: macro
 :toclevels: 2
 :toc-title: Releases
-:page-aliases: next@docs::ocis_release_notes.adoc
+:page-aliases: next@docs::ocis_release_notes.adoc, next@docs_main::ocis_release_notes.adoc
 
 :release-roadmap-url: https://github.com/owncloud/ocis/blob/master/docs/ocis/release_roadmap.md
 

--- a/modules/ROOT/pages/ocis_releases.adoc
+++ b/modules/ROOT/pages/ocis_releases.adoc
@@ -1,7 +1,7 @@
 = Infinite Scale Server Releases
 :toc: right
 :toclevels: 1
-:page-aliases: next@docs::ocis_releases.adoc
+:page-aliases: next@docs::ocis_releases.adoc, next@docs_main::ocis_releases.adoc
 
 :description: ownCloud provides in-depth documentation for Infinite Scale. Functionalities added or decommissioned dependent on a particular version are referenced in the documentation directly.
 

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -3,7 +3,7 @@
 :owncloud-server-changelog-url: https://owncloud.com/changelog/server/
 :page-aliases: {latest-server-version}@server:admin_manual:whats_new_admin.adoc, \
 {latest-server-version}@server:ROOT:server_release_notes.adoc, \
-next@docs::server_release_notes.adoc
+next@docs::server_release_notes.adoc, next@docs_main::server_release_notes.adoc
 
 * xref:changes-in-10-13-4[Changes in 10.13.4]
 * xref:changes-in-10-13-3[Changes in 10.13.3]

--- a/modules/ROOT/pages/server_releases.adoc
+++ b/modules/ROOT/pages/server_releases.adoc
@@ -1,7 +1,7 @@
 = ownCloud Server Releases
 :toc: right
 :toclevels: 3
-:page-aliases: releases.adoc, next@docs::server_releases.adoc
+:page-aliases: releases.adoc, next@docs::server_releases.adoc, next@docs_main::server_releases.adoc
 
 == Introduction
 


### PR DESCRIPTION
References: #23 

Add a page alias to all pages so that the former `docs_main/next` will still get resolved and redirected to the component less version. This eases life as some may not want to flush the browser cache. It is only 7 pages...
