### PR TITLE
Adding iOS and Android release notes

### DIFF
--- a/modules/ROOT/pages/android_release_notes.adoc
+++ b/modules/ROOT/pages/android_release_notes.adoc
@@ -1,0 +1,73 @@
+= Android App Release Notes
+:toc: macro
+:toclevels: 2
+:toc-title: Releases
+:description: Dear Android App user, find below the changes and known issues in the Andriod App that need your attention.
+
+:android-releases-url: https://github.com/owncloud/android/releases/tag/
+
+{description}
+
+{empty} +
+
+toc::[]
+
+== Android App 4.2.1
+
+[discrete]
+=== General
+
+This is a bugfix release only. Update as soon as possible.
+
+* Fixed some crashes in 4.2.0: https://github.com/owncloud/android/issues/4318[#4318]
+
+Refer to the full change log for a list of bug fixes and changes at {android-releases-url}/v4.2.1[GitHub, window=_blank].
+
+== Android App 4.2.0
+
+[discrete]
+=== General
+
+This release contains enhancements, bugfixes and security improvements. +
+Refer to the full change log for a list of bug fixes and changes at {android-releases-url}/v4.2.0[GitHub, window=_blank].
+
+[discrete]
+=== Security Improvements
+
+* Improve biometric authentication security: https://github.com/owncloud/android/issues/4180[#4180]
+
+[discrete]
+=== Notable Enhancements
+
+* New MDM functionalities, see: https://github.com/owncloud/android/issues/4249[#4249] and https://github.com/owncloud/android/issues/4288[#4288]
+* Thumbnail improvements in grid view: https://github.com/owncloud/android/issues/4145[#4145]
+* Auto upload in oCIS accounts allows upload to any space: https://github.com/owncloud/android/issues/4117[#4117]
+* "Share to" in oCIS accounts allows upload to any space: https://github.com/owncloud/android/issues/4088[#4088]
+
+== Android App 4.1.1
+
+[discrete]
+=== General
+
+This is a bugfix release only. Update as soon as possible.
+
+* Some Null Pointer Exceptions avoided: https://github.com/owncloud/android/issues/4158[#4158]
+* Thumbnails correctly shown for every user: https://github.com/owncloud/android/pull/4189[#4189]
+
+Refer to the full change log for a list of bug fixes and changes at {android-releases-url}/v4.1.1[GitHub, window=_blank].
+
+== Android App 4.1.0
+
+[discrete]
+=== General
+
+This release contains enhancements and bugfixes. +
+Refer to the full change log for a list of bug fixes and changes at {android-releases-url}/v4.1.0[GitHub, window=_blank].
+
+[discrete]
+=== Notable Enhancements
+
+* Show "More" button for every file list item: https://github.com/owncloud/android/issues/2885[#2885]
+* Added "Open in web" options to main file list: https://github.com/owncloud/android/issues/3860[#3860]
+* Force security if not protected: https://github.com/owncloud/android/issues/4061[#4061]
+* Prevent http traffic with branding options: https://github.com/owncloud/android/issues/4066[#4066]

--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -77,7 +77,6 @@ ownCloud Desktop App 5.2.1 also delivers several important technical improvement
 * openSUSE Leap 15.5
 * Ubuntu 23.10
 
-
 [discrete]
 === Deprecated Platforms
 

--- a/modules/ROOT/pages/ios_release_notes.adoc
+++ b/modules/ROOT/pages/ios_release_notes.adoc
@@ -1,0 +1,83 @@
+= iOS App Release Notes
+:toc: macro
+:toclevels: 2
+:toc-title: Releases
+:description: Dear iOS App user, find below the changes and known issues in the iOS App that need your attention.
+
+:ios-releases-url: https://github.com/owncloud/ios-app/releases/tag
+
+{description}
+
+{empty} +
+
+toc::[]
+
+== iOS App 12.1.0
+
+[discrete]
+=== General
+
+This release contains changes and bugfixes. +
+Refer to the full change log for a list of bug fixes and changes at {ios-releases-url}/v12.1[GitHub, window=_blank].
+
+[discrete]
+=== Notable Changes
+
+* New account wizard: https://github.com/owncloud/ios-app/pull/1274[#1274]
+* Text recognition actions for images: https://github.com/owncloud/ios-app/pull/1283[#1283]
+* Share Action Extension "Save to ownCloud": https://github.com/owncloud/ios-app/issues/1293[#1293]
+* File extension / suffix protection: https://github.com/owncloud/ios-app/issues/1292[#1292]
+
+== iOS App 12.0.3
+
+[discrete]
+=== General
+
+This is a bugfix release only. Update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ios-releases-url}/v12.0.3[GitHub, window=_blank].
+
+== iOS App 12.0.2
+
+[discrete]
+=== General
+
+This is a bugfix release only. Update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ios-releases-url}/v12.0.2[GitHub, window=_blank].
+
+== iOS App 12.0.1
+
+[discrete]
+=== General
+
+This is a bugfix release only. Update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ios-releases-url}/v12.0.1[GitHub, window=_blank].
+
+== iOS App 12.0.0
+
+[discrete]
+=== General
+
+This is a major release with many enhancements, bugfixes and security fixes. +
+Refer to the full change log for a list of bug fixes and changes at {ios-releases-url}/v12.0.0[GitHub, window=_blank].
+
+[discrete]
+=== Notable Enhancements
+
+* Version 12 Major Release +
+Rearchitectured for iOS 15 and later.
+* ownCloud Infinite Scale support +
+Support for Spaces, Authenticated WebFinger and other new oCIS features.
+* New Search Capabilities +
+Powerful new search UI, saved searches and search templates.
+* New Navigation +
+Navigate via the new sidebar, breadcrumbs and browser controls.
+* Role-based Sharing Interface +
+The new role-based sharing user interface makes creating and editing shares and links even easier.
+* Grid View Modes +
+Switch between list and several, different grid modes to display your folder's contents in new ways.
+* App Provider support +
+Create and edit new documents through app providers on servers that support them.
+* Improved Theming +
+The updated dark and light themes make use of a new, CSS-based theming system.
+* MDM Enhancements +
+Many new MDM parameters.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -6,6 +6,8 @@
 ** xref:server_release_notes.adoc[ownCloud Server Release Notes]
 * xref:client_releases.adoc[App Releases]
 ** xref:desktop_release_notes.adoc[Desktop App Release Notes]
+** xref:ios_release_notes.adoc[iOS App Release Notes]
+** xref:android_release_notes.adoc[Android App Release Notes]
 // * xref:webui_releases.adoc[ownCloud Web UI Releases]
 // * xref:webui_releases_notes.adoc[ownCloud Web UI Release Notes]
 * xref:how_to_contribute.adoc[How to Contribute]


### PR DESCRIPTION
Adding the iOS and Android release notes to have all apps completed.

The release notes page in the apps will be removed as it contains nothing valuable.

@tbsbdr fyi