### PR TITLE
Add a temporary page alias for the desktop release notes

### DIFF
--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -3,6 +3,8 @@
 :toclevels: 2
 :toc-title: Releases
 :description: Dear Desktop App user, find below the changes and known issues in the Desktop App that need your attention.
+:page-aliases: 5.2@desktop:ROOT:appendices/release_notes.adoc
+// IMPORTANT: this page alias must be removed at the moment 5.2 is no longer active!!
 
 :desktop-releases-url: https://github.com/owncloud/client/releases/tag/
 


### PR DESCRIPTION
This PR adds a temporary page alias for the desktop release notes so they can be accessible via: [desktop/5.2/appendices/release_notes.html](https://doc.owncloud.com/desktop/5.2/appendices/release_notes.html)

Locally tested via a full docs build ✔️ 

@tbsbdr fyi, as discussed