### PR TITLE
Add release notes for ocis 5.0.1

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -15,6 +15,27 @@
 
 toc::[]
 
+== Infinite Scale 5.0.1
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.1[GitHub, window=_blank].
+
+[discrete]
+=== Issues Fixed
+
+* Update reva to v2.19.4: Use gateway selector in jsoncs3 to scale the service: https://github.com/owncloud/ocis/pull/8787[#8787]
+* Update reva to v2.19.3: Mask user email in output: https://github.com/owncloud/ocis/pull/8781[#8781]
+* Make IDP cookies same site strict: https://github.com/owncloud/ocis/pull/8799[#8799]
+* Fix restarting of postprocessing: https://github.com/owncloud/ocis/pull/8782[#8782]
+
+[discrete]
+=== Enhancement
+
+* Make IDP cookies same site strict: https://github.com/owncloud/ocis/pull/8716[#8716]
+
 == Infinite Scale 5.0.0
 
 [discrete]

--- a/site.yml
+++ b/site.yml
@@ -74,9 +74,9 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     # these versions are just for printing like in releases but not used for referencing
-    ocis-actual-version: '4.0.4'
-    ocis-former-version: '3.0.0'
-    ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
+    ocis-actual-version: '5.0.1'
+    ocis-former-version: '4.0.7'
+    ocis-compiled: '2024-04-10 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   webui
     latest-webui-version: 'next'


### PR DESCRIPTION
Refernces: https://github.com/owncloud/ocis/pull/8825 ([full-ci] Prepare Release 5.0.1)

Adds release notes for ocis 5.0.1 based on the changes in the referenced PR.

Note that the changes in site.yml are just for local building and have no impact on a full build but they should be "as close as possible" 😄 

Should be merged close after the new version is publicly available.