### PR TITLE
Add ocis 5.0.2 release notes

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -15,6 +15,20 @@
 
 toc::[]
 
+== Infinite Scale 5.0.2
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.1[GitHub, window=_blank].
+
+[discrete]
+=== Issues Fixed
+
+* Update reva to v2.19.5: Fix public share update and Fix access to files withing a public link targeting a space root: https://github.com/owncloud/ocis/pull/8873[#8873]
+* Creating a new Office document in a publicly shared folder is now possible: https://github.com/owncloud/ocis/pull/8828[#8828]
+
 == Infinite Scale 5.0.1
 
 [discrete]

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -21,12 +21,12 @@ toc::[]
 === General
 
 This is a patch release only, please update as soon as possible. +
-Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.1[GitHub, window=_blank].
+Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.2[GitHub, window=_blank].
 
 [discrete]
 === Issues Fixed
 
-* Update reva to v2.19.5: Fix public share update and Fix access to files withing a public link targeting a space root: https://github.com/owncloud/ocis/pull/8873[#8873]
+* Update reva to v2.19.5: Fix public share update and Fix access to files within a public link targeting a space root: https://github.com/owncloud/ocis/pull/8873[#8873]
 * Creating a new Office document in a publicly shared folder is now possible: https://github.com/owncloud/ocis/pull/8828[#8828]
 
 == Infinite Scale 5.0.1


### PR DESCRIPTION
Add ocis 5.0.2 release notes.

Release changes in docs and docs-ocis are on the way.