### PR TITLE
Add release notes for ocis 5.0.4

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -15,6 +15,21 @@
 
 toc::[]
 
+== Infinite Scale 5.0.4
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.4[GitHub, window=_blank].
+
+[discrete]
+=== Issues Fixed
+
+* Update reva to v2.19.7: Reworks virus handling: https://github.com/owncloud/ocis/pull/9141[#9141]
+* Service startup of WOPI example: https://github.com/owncloud/ocis/pull/9127[#9127]
+* Nats reconnects: https://github.com/owncloud/ocis/pull/9139[#9139]
+
 == Infinite Scale 5.0.3
 
 [discrete]

--- a/site.yml
+++ b/site.yml
@@ -74,7 +74,7 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     # these versions are just for printing like in releases but not used for referencing
-    ocis-actual-version: '5.0.1'
+    ocis-actual-version: '5.0.4'
     ocis-former-version: '4.0.7'
     ocis-compiled: '2024-04-10 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'


### PR DESCRIPTION
Infinite scale 5.0.4 has been released - this are the release notes.