### PR TITLE
Add release notes for desktop 5.3.1

### DIFF
--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -14,6 +14,21 @@
 
 toc::[]
 
+== Desktop App 5.3.1
+
+[discrete]
+=== General
+
+The ownCloud Desktop App is now available in version 5.3.1! +
+We strongly recommend updating the Desktop App to the latest available version so that you can access and experience a range of new features and security fixes. Users with an Enterprise subscription are entitled to receive dedicated support.
+
+Refer to the full change log for a list of bug fixes and changes at {desktop-releases-url}v5.3.1[GitHub, window=_blank].
+
+[discrete]
+=== Notable Bugfixes
+
+* Ensure the Windows shell extension is linked statically
+
 == Desktop App 5.3.0
 
 [discrete]

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -1005,12 +1005,12 @@ With all these improvements we want to motivate ownCloud service providers to ma
 
 TIP: ownCloud Web is currently in the status of a Technology Preview. This means that bugs and other undesired behavior are expected. After careful testing, ownCloud Web can be used on production systems. Features are still being added to ownCloud Web and users will need to use the Classic web interface to do certain actions. Please evaluate according to your use case how well the new web interface suits your needs and let us know any feedback that you encounter.
 
-==== Fixed Known Issues
+=== Fixed Known Issues
 
 Both xref:server_release_notes.adoc#known-issues-10-7[known issues from ownCloud Server 10.7] have been fixed. The deployment of ownCloud Web is now more robust and administrators can optionally decide whether ownCloud Links (public and private links) should be provided by the Classic web interface or by ownCloud Web using a https://owncloud.dev/clients/web/deployments/oc10-app/#configure-link-routing[new option in config.php].
 
 [discrete]
-==== Feedback
+=== Feedback
 
 As mentioned, features are still being added to ownCloud Web and the new web interface can't yet cover every use case of the Classic interface. To further shape the new product and to determine the development priorities it is of utmost importance to consider user feedback. We're very grateful for any hints or feedback that you supply via the following channels
 

--- a/site.yml
+++ b/site.yml
@@ -2,7 +2,7 @@
 site:
   title: ownCloud Main Page
   url: https://doc.owncloud.com
-  start_page: docs_main::index.adoc
+  start_page: ROOT::index.adoc
 
 content:
   sources:


### PR DESCRIPTION
This PR:

* Adds release notes for Desktop 5.3.1
* Fixes a section out of sequence in the server release notes
* Fixes a local only build warning that the index.adoc file cant be found