### PR TITLE
Prepare for ocis 5.0.6 release notes

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -16,6 +16,21 @@
 
 toc::[]
 
+== Infinite Scale 5.0.6 (Production)
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.6[GitHub, window=_blank].
+
+////
+[discrete]
+=== Enhancement
+
+* Update web to v8.0.2: https://github.com/owncloud/ocis/pull/8716[#8716]
+////
+
 == Infinite Scale 6.1.0 (Rolling)
 
 IMPORTANT: This is a Rolling Release. Please check the {release-types-url}[documentation] to see if this release type is right for your use case.

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -24,12 +24,18 @@ toc::[]
 This is a patch release only, please update as soon as possible. +
 Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.6[GitHub, window=_blank].
 
-////
+[discrete]
+=== Issues Fixed
+
+* Allow all uploads to restart: Reworks virus handling: https://github.com/owncloud/ocis/pull/9506[#9506]
+* Fix the email notification service: https://github.com/owncloud/ocis/pull/9514[#9514]
+
 [discrete]
 === Enhancement
 
-* Update web to v8.0.2: https://github.com/owncloud/ocis/pull/8716[#8716]
-////
+* Limit concurrent thumbnail requests: https://github.com/owncloud/ocis/pull/9199[#9199]
+* Update web to v8.0.4: https://github.com/owncloud/ocis/pull/9429[#9429]
+* Add cli to purge revisions: https://github.com/owncloud/ocis/pull/9497[#9497]
 
 == Infinite Scale 6.1.0 (Rolling)
 


### PR DESCRIPTION
This is the starting point for the 5.0.6 docs to make adding content more easy.

Note that the commented line is by intention to have a first structure. Uncomment and change stuff as needed...