### PR TITLE
Add release notes for ocis 5.0.7

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -16,6 +16,21 @@
 
 toc::[]
 
+== Infinite Scale 5.0.7 (Production)
+
+[discrete]
+=== General
+
+This is a patch release only, please update as soon as possible. +
+Refer to the full change log for a list of bug fixes and changes at {ocis-releases-url}/v5.0.7[GitHub, window=_blank].
+
+[discrete]
+=== Enhancement
+
+* Add virus filter to sessions command: https://github.com/owncloud/ocis/pull/9041[#9041]
+* Assimilate `clean` into `sessions` command: https://github.com/owncloud/ocis/pull/9828[#9828]
+* Update web to v8.0.5: https://github.com/owncloud/ocis/pull/9958[#9958]
+
 == Infinite Scale 6.3.0 (Rolling)
 
 IMPORTANT: This is a Rolling Release. Please check the {release-types-url}[documentation] to see if this release type is right for your use case.


### PR DESCRIPTION
As the title says, derived from https://github.com/owncloud/ocis/issues/9962 (Patch Release 5.0.7)

Merge only after the release has been published - putting to draft therefore.

@tbsbdr fyi