### PR TITLE
Remove double entry in iOS release notes

### DIFF
--- a/modules/ROOT/pages/ios_release_notes.adoc
+++ b/modules/ROOT/pages/ios_release_notes.adoc
@@ -39,7 +39,6 @@ Refer to the full change log for a list of bug fixes and changes at {ios-release
 NOTE: This is the first release supporting iOS 18
 
 * Fix cleanup of Available Offline policies targeting unavailable spaces: https://github.com/owncloud/ios-app/pull/1344[#1344]
-* Reduce memory footprint: https://github.com/owncloud/ios-app/pull/1376[#1376]
 * Improved sidebar with account-wide search: https://github.com/owncloud/ios-app/pull/1320[#1320]
 * Sync Engine fixes and improvements: https://github.com/owncloud/ios-app/pull/1376[#1376]
 * Reduce memory footprint: https://github.com/owncloud/ios-app/pull/1376[#1376]


### PR DESCRIPTION
That entry was double present - removed