### PR TITLE
Added Release Notes 6.6.0

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -16,6 +16,37 @@
 
 toc::[]
 
+== Infinite Scale 6.6.0 (Rolling)
+
+IMPORTANT: This is a Rolling Release. Please check the {release-types-url}[documentation] to see if this release type is right for your use case.
+
+Refer to the source and the full change log for a list of bug fixes and changes at {ocis-releases-url}/v6.5.0[GitHub, window=_blank].
+
+[discrete]
+=== 10x Faster Image Previews
+
+Infinite Scale now uses libvips for image processing, making photo previews appear up to 10x faster when uploading large folders. This update significantly improves performance, especially for handling large batches of images.
+
+Note: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. https://github.com/owncloud/ocis/blob/master/services/thumbnails/README.md#using-libvips-for-thumbnail-generation[More details]
+
+[discrete]
+=== 20 Newly Supported Image Formats like HEIC/HEIF or WebP
+
+Infinite Scale now supports 20 additional image formats: TIFF (with advanced features), WebP, HEIC/HEIF, AVIF, PDF, SVG, JPEG 2000, JPEG XL, DNG (RAW format), HDR (Radiance), PPM/PGM/PBM/PFM, OpenEXR, FITS, Matlab, VIPS native format, Analyze, NIfTI, DeepZoom, OpenSlide formats (e.g. SVS, NDPI, SCN)
+
+Note: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. https://github.com/owncloud/ocis/blob/master/services/thumbnails/README.md#using-libvips-for-thumbnail-generation[More details]
+
+[discrete]
+=== Only Office: 1-Click Document Templates
+
+Easily create documents from templates with a single click. Just select an office template eg. from a "Templates" Space and the templated document will open automatically, just like on your desktop. Your new document will be saved in your Personal storage with the template name as the filename. Supported template formats are: DOTX, OTT, XLTX, POTX, OTS and OTP.
+
+=== Known Issues
+
+**OCM Federation: No Image Preview in Browser** 
+
+A user receiving an image via OCM (Open Cloud Mesh) federation cannot view it directly in the browser. Users must download the image from the web to view it. Status of the issue: https://github.com/owncloud/ocis/issues/10272[github.com/owncloud/ocis/issues/10272] Please note: OCM is still classified as a feature preview (i.e., it works, but production use should be discussed with ownCloud support). This is because OCM was initially developed for the scientific community as early adopters. Its use in other environments is not yet recommended.
+
 == Infinite Scale 6.5.0 (Rolling)
 
 IMPORTANT: This is a Rolling Release. Please check the {release-types-url}[documentation] to see if this release type is right for your use case.

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -25,16 +25,21 @@ Refer to the source and the full change log for a list of bug fixes and changes 
 [discrete]
 === 10x Faster Image Previews
 
-Infinite Scale now uses libvips for image processing, making photo previews appear up to 10x faster when uploading large folders. This update significantly improves performance, especially for handling large batches of images.
+* Infinite Scale now uses the `libvips` shared library for image processing.
+** Photo previews appear up to 10x faster when uploading large folders.
+** The handling of large image batches is greatly improved.
 
-Note: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. https://github.com/owncloud/ocis/blob/master/services/thumbnails/README.md#using-libvips-for-thumbnail-generation[More details]
++
+NOTE: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. See the xref:next@ocis:ROOT:deployment/services/s-list/thumbnails.adoc#thumbnailing-performance[thumbnail service] for more details.
 
 [discrete]
 === 20 Newly Supported Image Formats like HEIC/HEIF or WebP
 
-Infinite Scale now supports 20 additional image formats: TIFF (with advanced features), WebP, HEIC/HEIF, AVIF, PDF, SVG, JPEG 2000, JPEG XL, DNG (RAW format), HDR (Radiance), PPM/PGM/PBM/PFM, OpenEXR, FITS, Matlab, VIPS native format, Analyze, NIfTI, DeepZoom, OpenSlide formats (e.g. SVS, NDPI, SCN)
+* Infinite Scale now supports 20 additional image formats:
+** TIFF (with advanced features), WebP, HEIC/HEIF, AVIF, PDF, SVG, JPEG 2000, JPEG XL, DNG (RAW format), HDR (Radiance), PPM/PGM/PBM/PFM, OpenEXR, FITS, Matlab, VIPS native format, Analyze, NIfTI, DeepZoom, OpenSlide formats (e.g. SVS, NDPI, SCN).
 
-Note: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. https://github.com/owncloud/ocis/blob/master/services/thumbnails/README.md#using-libvips-for-thumbnail-generation[More details]
++
+NOTE: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. See the xref:next@ocis:ROOT:deployment/services/s-list/thumbnails.adoc#thumbnailing-performance[thumbnail service] for more details.
 
 [discrete]
 === Only Office: 1-Click Document Templates
@@ -43,9 +48,8 @@ Easily create documents from templates with a single click. Just select an offic
 
 === Known Issues
 
-**OCM Federation: No Image Preview in Browser** 
-
-A user receiving an image via OCM (Open Cloud Mesh) federation cannot view it directly in the browser. Users must download the image from the web to view it. Status of the issue: https://github.com/owncloud/ocis/issues/10272[github.com/owncloud/ocis/issues/10272] Please note: OCM is still classified as a feature preview (i.e., it works, but production use should be discussed with ownCloud support). This is because OCM was initially developed for the scientific community as early adopters. Its use in other environments is not yet recommended.
+OCM Federation: No Image Preview in Browser::
+A user receiving an image via an OCM (Open Cloud Mesh) federation cannot view it directly in the browser. Users must download the image from the web to view it. For the status of the issue see: https://github.com/owncloud/ocis/issues/10272[github.com/owncloud/ocis/issues/10272]. Please note that OCM is still classified as a feature preview (e.g. it works, but production use should be discussed with ownCloud support). This is because OCM was initially developed for the scientific community as early adopters. Its use in other environments is not yet recommended.
 
 == Infinite Scale 6.5.0 (Rolling)
 

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -44,12 +44,12 @@ NOTE: This improvement is exclusively available for containerized deployments. I
 [discrete]
 === Only Office: 1-Click Document Templates
 
-Easily create documents from templates with a single click. Just select an office template eg. from a "Templates" Space and the templated document will open automatically, just like on your desktop. Your new document will be saved in your Personal storage with the template name as the filename. Supported template formats are: DOTX, OTT, XLTX, POTX, OTS and OTP.
+Easily create documents from templates with a single click. Just select an office template, e.g. from a "Templates" Space, and the templated document will open automatically, just like on your desktop. Your new document will be saved in your Personal storage with the template name as the filename. Supported template formats are: DOTX, OTT, XLTX, POTX, OTS and OTP.
 
 === Known Issues
 
 OCM Federation: No Image Preview in Browser::
-A user receiving an image via an OCM (Open Cloud Mesh) federation cannot view it directly in the browser. Users must download the image from the web to view it. For the status of the issue see: https://github.com/owncloud/ocis/issues/10272[github.com/owncloud/ocis/issues/10272]. Please note that OCM is still classified as a feature preview (e.g. it works, but production use should be discussed with ownCloud support). This is because OCM was initially developed for the scientific community as early adopters. Its use in other environments is not yet recommended.
+A user receiving an image via an OCM (Open Cloud Mesh) federation cannot view it directly in the browser. Users must download the image from the web to view it. For the status of the issue see: https://github.com/owncloud/ocis/issues/10272[github.com/owncloud/ocis/issues/10272]. Please note that OCM is still classified as a feature preview (i.e. it works, but production use should be discussed with ownCloud support). This is because OCM was initially developed for the scientific community as early adopters. Its use in other environments is not yet recommended.
 
 == Infinite Scale 6.5.0 (Rolling)
 

--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -23,20 +23,11 @@ IMPORTANT: This is a Rolling Release. Please check the {release-types-url}[docum
 Refer to the source and the full change log for a list of bug fixes and changes at {ocis-releases-url}/v6.5.0[GitHub, window=_blank].
 
 [discrete]
-=== 10x Faster Image Previews
+=== 4x Faster Image Previews
 
 * Infinite Scale now uses the `libvips` shared library for image processing.
-** Photo previews appear up to 10x faster when uploading large folders.
+** Photo previews appear up to 4x faster when uploading large folders.
 ** The handling of large image batches is greatly improved.
-
-+
-NOTE: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. See the xref:next@ocis:ROOT:deployment/services/s-list/thumbnails.adoc#thumbnailing-performance[thumbnail service] for more details.
-
-[discrete]
-=== 20 Newly Supported Image Formats like HEIC/HEIF or WebP
-
-* Infinite Scale now supports 20 additional image formats:
-** TIFF (with advanced features), WebP, HEIC/HEIF, AVIF, PDF, SVG, JPEG 2000, JPEG XL, DNG (RAW format), HDR (Radiance), PPM/PGM/PBM/PFM, OpenEXR, FITS, Matlab, VIPS native format, Analyze, NIfTI, DeepZoom, OpenSlide formats (e.g. SVS, NDPI, SCN).
 
 +
 NOTE: This improvement is exclusively available for containerized deployments. It is not available for bare-metal deployments, which run the Infinite Scale executable without Docker, Kubernetes or similar platforms. See the xref:next@ocis:ROOT:deployment/services/s-list/thumbnails.adoc#thumbnailing-performance[thumbnail service] for more details.


### PR DESCRIPTION
- 4x Faster Image Previews
~~- 20 Newly Supported Image Formats like HEIC/HEIF or WebP~~ NOT yet implemented
- Only Office: 1-Click Document Templates
- Known Issues: OCM Federation: No Image Preview in Browser

@kulmann @micbar
Could you please also check correctness of content? I was not 100% sure about newly supported image file formats and supported template file formats 🙏 thanks