### PR TITLE
Remove OC10 appliance reference

### DIFF
--- a/modules/ROOT/pages/server_releases.adoc
+++ b/modules/ROOT/pages/server_releases.adoc
@@ -29,11 +29,14 @@ include::partial$maintenance-release-schedule-link.adoc[]
 * xref:{previous-webui-version}@webui:classic_ui:index.adoc[User Manual]
 //   ({docs-base-url}/pdf/webui/{previous-webui-version}_ownCloud_User_Manual.pdf[Download PDF])
 
+////
+// the appliance has been removed from the docs in 10.14 upwards
 === ownCloud X Appliance
 
 The ownCloud X Appliance is a complete virtual machine image running ownCloud X, on _Univention Server_.
 
 * xref:{latest-server-version}@server:admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
+////
 
 == Older ownCloud Server Releases
 


### PR DESCRIPTION
The appliance docs have been removed, we also need to remove the dead link to avoid build warnings.