### PR TITLE
Finally remove already commented text block

### DIFF
--- a/modules/ROOT/pages/server_releases.adoc
+++ b/modules/ROOT/pages/server_releases.adoc
@@ -29,15 +29,6 @@ include::partial$maintenance-release-schedule-link.adoc[]
 * xref:{previous-webui-version}@webui:classic_ui:index.adoc[User Manual]
 //   ({docs-base-url}/pdf/webui/{previous-webui-version}_ownCloud_User_Manual.pdf[Download PDF])
 
-////
-// the appliance has been removed from the docs in 10.14 upwards
-=== ownCloud X Appliance
-
-The ownCloud X Appliance is a complete virtual machine image running ownCloud X, on _Univention Server_.
-
-* xref:{latest-server-version}@server:admin_manual:appliance/index.adoc[ownCloud X Appliance Manual]
-////
-
 == Older ownCloud Server Releases
 
 include::partial$maintenance-release-schedule-link.adoc[]


### PR DESCRIPTION
References: #87 (Remove OC10 appliance reference)

Commenting made the full build process run without warning, we now can finally remove the text block.