### PR TITLE
Remove the Branding docs from the main page

### DIFF
--- a/modules/ROOT/pages/client_releases.adoc
+++ b/modules/ROOT/pages/client_releases.adoc
@@ -51,11 +51,5 @@ The latest ownCloud Android App release, suitable for production use.
 * xref:{previous-android-version}@android:ROOT:index.adoc[ownCloud Android App Manual]
 //  ({docs-base-url}/pdf/android/{previous-android-version}_ownCloud_Android_App_Manual.pdf[Download PDF])
 
-== Building Branded ownCloud Clients (Enterprise only)
-
-Instructions for building branded ownCloud iOS, Android, and Desktop Sync clients.
-
-* xref:{latest-branded-version}@branded_clients:ROOT:index.adoc[Building Branded ownCloud Clients]
-//  ({docs-base-url}/pdf/branded_clients/{latest-branded-version}_ownCloud_Branded_Clients_Manual.pdf[Download PDF])
 
 All documentation licensed under the Creative Commons Attribution 3.0 Unported license.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -29,4 +29,3 @@
 * xref:{latest-desktop-version}@desktop:ROOT:index.adoc[Desktop App]
 * xref:{latest-android-version}@android:ROOT:index.adoc[Mobile App for Android]
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[Mobile App for iOS]
-* xref:{latest-branded-version}@branded_clients:ROOT:index.adoc[Branded Clients]


### PR DESCRIPTION
Based on the request of @DeepDiver1975

This PR removes the branding docs from the navigation and client overview page. It must be merged BEFORE removing the branding docs from the build process. 