### PR TITLE
Relocate the classic UI component to the docs-server repo

### DIFF
--- a/modules/ROOT/pages/server_releases.adoc
+++ b/modules/ROOT/pages/server_releases.adoc
@@ -17,7 +17,7 @@ include::partial$maintenance-release-schedule-link.adoc[]
 //  ({docs-base-url}/pdf/server/{latest-server-version}_ownCloud_Admin_Manual.pdf[Download PDF])
 * xref:{latest-server-version}@server:developer_manual:index.adoc[Developer Manual]
 //  ({docs-base-url}/pdf/server/{latest-server-version}_ownCloud_Developer_Manual.pdf[Download PDF])
-* xref:{latest-webui-version}@webui:classic_ui:index.adoc[User Manual]
+* xref:{latest-webui-version}@server:classic_ui:index.adoc[User Manual]
 //   ({docs-base-url}/pdf/webui/{latest-webui-version}_ownCloud_User_Manual.pdf[Download PDF])
 
 === Previous Stable Release (version {previous-server-version})
@@ -26,7 +26,7 @@ include::partial$maintenance-release-schedule-link.adoc[]
 //  ({docs-base-url}/pdf/server/{previous-server-version}_ownCloud_Admin_Manual.pdf[Download PDF])
 * xref:{previous-server-version}@server:developer_manual:index.adoc[Developer Manual]
 //  ({docs-base-url}/pdf/server/{previous-server-version}_ownCloud_Developer_Manual.pdf[Download PDF])
-* xref:{previous-webui-version}@webui:classic_ui:index.adoc[User Manual]
+* xref:{previous-webui-version}@server:classic_ui:index.adoc[User Manual]
 //   ({docs-base-url}/pdf/webui/{previous-webui-version}_ownCloud_User_Manual.pdf[Download PDF])
 
 == Older ownCloud Server Releases

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -8,8 +8,6 @@
 ** xref:desktop_release_notes.adoc[Desktop App Release Notes]
 ** xref:ios_release_notes.adoc[iOS App Release Notes]
 ** xref:android_release_notes.adoc[Android App Release Notes]
-// * xref:webui_releases.adoc[ownCloud Web UI Releases]
-// * xref:webui_releases_notes.adoc[ownCloud Web UI Release Notes]
 * xref:how_to_contribute.adoc[How to Contribute]
 
 // note, atm we cant include an existing component navigation via e.g.,
@@ -25,7 +23,8 @@
 * xref:{latest-server-version}@server:ROOT:index.adoc[ownCloud Server]
 
 .Apps and User Interfaces
-* xref:{latest-webui-version}@webui:ROOT:index.adoc[Web]
+* xref:{latest-webui-version}@webui:ROOT:index.adoc[Web Infinite Scale]
+* xref:{latest-server-version}@server:classic_ui:index.adoc[Web ownCloud Server]
 * xref:{latest-desktop-version}@desktop:ROOT:index.adoc[Desktop App]
 * xref:{latest-android-version}@android:ROOT:index.adoc[Mobile App for Android]
 * xref:{latest-ios-version}@ios-app:ROOT:index.adoc[Mobile App for iOS]


### PR DESCRIPTION
This PR moves references  of the `classic_ui` module (ownCloud Server UI) to `server`.
The module will be added in the `docs-server` repo.

Note that the order of merging the various PR is important. Relevant PR`s will get referenced.
