### PR TITLE
Add Desktop 5.3.2 release notes

### DIFF
--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -14,6 +14,23 @@
 
 toc::[]
 
+== Desktop App 5.3.2
+
+[discrete]
+=== General
+
+The ownCloud Desktop App is now available in version 5.3.2! +
+We strongly recommend updating the Desktop App to the latest available version so that you can access and experience a range of new features and security fixes. Users with an Enterprise subscription are entitled to receive dedicated support.
+
+Refer to the full change log for a list of bug fixes and changes at {desktop-releases-url}v5.3.2[GitHub, window=_blank].
+
+[discrete]
+=== Notable Bugfixes
+
+* Security: Fixing high security vulnerability in Windows Installer
+* Bugfix: OAuth: Prevent logout when refreshing token
+* Bugfix: Crash when checking the sync file status
+
 == Desktop App 5.3.1
 
 [discrete]


### PR DESCRIPTION
Adding the Desktop 5.3.2 release notes. This is a patch release only, no branching in `docs-client-desktop` encessary.