### PR TITLE
Release notes for ocis 7.1.1

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -16,6 +16,22 @@
 
 toc::[]
 
+== Infinite Scale 7.1.1 (Production)
+
+This release is a bugfix release for the backend and implements some enhancements for the webUI only.
+
+Please find the most important changes described here or refer to the changelog for a complete list of changes:
+
+* Infinite Scale: {ocis-releases-url}/v7.1.1[Changes in 7.1.1, window=_blank]
+* Web: {web-releases-url}/v11.3.1[Changelog for ownCloud Web 11.3.1, window=_blank]
+
+[discrete]
+=== Issues Fixed
+
+* General translation updates sourced from both the ocis and the web repo. 
+* Fix translations of editor roles: https://github.com/owncloud/ocis/pull/11116[#11116]
+* Several bugfixes for password protected folders and other small fixes. For details see the: {ocis-releases-url}/v7.1.1[webUI changelog, window=_blank]
+
 == Infinite Scale 7.1.0 (Production)
 
 Please find the most important changes described here or refer to the changelog for a complete list of changes:


### PR DESCRIPTION
References: https://github.com/owncloud/docs-ocis/pull/1146 (Update ocis to 7.1.1)

This PR adds release notes for ocis 7.1.1