### PR TITLE
Add Android 4.5.0 Release Notes

### DIFF
--- a/modules/ROOT/pages/android_release_notes.adoc
+++ b/modules/ROOT/pages/android_release_notes.adoc
@@ -47,7 +47,7 @@ Added feedback with some messages in the snackbars when the user sets or un-sets
 Enabling logs and sending them to us is the best way to help us improve the app and provide the best user experience.
 
 ** By default, logging is disabled. +
-To activate them, you have to go to menu:Settings[Logging > Enable logging]. Since the moment they are on, logs will keep track of every event occurring in the app. These DON’T include user’s sensitive information, so they can be used safely.
+To activate them, you have to go to menu:Settings[Logging > Enable logging]. From the moment they are on, logs will keep track of every event occurring in the app. These DON’T include user’s sensitive information, so they can be used safely.
 
 ** Once logging is enabled and some actions have been performed within the application, log files will be created. To view them, go to menu:Settings[Logging > Log Files]. There you can easily share them by tapping the share icon.
 

--- a/modules/ROOT/pages/android_release_notes.adoc
+++ b/modules/ROOT/pages/android_release_notes.adoc
@@ -12,6 +12,51 @@
 
 toc::[]
 
+== Android App 4.5.0
+
+[discrete]
+=== General
+
+This release contains bugfixes, changes and enhancements. +
+Refer to the full change log for a list of bug fixes and changes at {android-releases-url}v4.5.0[GitHub, window=_blank].
+
+[discrete]
+=== Issues Fixed
+
+* Replaced the phrase auto-uploads with automatic uploads.
+* Fixed navigation in Automatic Uploads folder picker.
+* Fixed folder size after move operation.
+* Other bug fixes and technical improvements.
+
+[discrete]
+=== Enhancements
+
+* Improvements in storage occupation display. +
+Quotas are updated in more file operations such as `copy`, `move`, `delete`, `upload`, etc that change the user's disk usage. In addition, the storage usage of each account has been added to the Manage Accounts dialog.
+
+* Infinite Scale Users Light. +
+From now on, the application supports Infinite Scale Users Light (those who don't have personal space). All the functionalities have been adapted to allow this type of users to use the application correctly, taking into account all their limitations.
+
+* Added text labels on bottom bar. +
+Text labels have been added to all the items that appear in the bottom navigation bar to provide enough and clear information about the available sections that we have.
+
+* Feedback when (un)setting av. offline in all previews. +
+Added feedback with some messages in the snackbars when the user sets or un-sets a file as available offline in the file preview. The status is now easily identifiable.
+
+* Logging in the ownCloud Android App. +
+Enabling logs and sending them to us is the best way to help us improve the app and provide the best user experience.
+
+** By default, logging is disabled. +
+To activate them, you have to go to menu:Settings[Logging > Enable logging]. Since the moment they are on, logs will keep track of every event occurring in the app. These DON’T include user’s sensitive information, so they can be used safely.
+
+** Once logging is enabled and some actions have been performed within the application, log files will be created. To view them, go to menu:Settings[Logging > Log Files]. There you can easily share them by tapping the share icon.
+
+* Sending feedback to ownCloud developers. +
+If you find a bug or want to make any suggestions, please participate in one of these channels:
+
+** Open a new issue on https://github.com/owncloud/android/issues[GitHub].
+** Open a new topic on https://central.owncloud.org[Central].
+
 == Android App 4.4.0
 
 [discrete]

--- a/modules/ROOT/pages/android_release_notes.adoc
+++ b/modules/ROOT/pages/android_release_notes.adoc
@@ -35,7 +35,7 @@ Refer to the full change log for a list of bug fixes and changes at {android-rel
 Quotas are updated in more file operations such as `copy`, `move`, `delete`, `upload`, etc that change the user's disk usage. In addition, the storage usage of each account has been added to the Manage Accounts dialog.
 
 * Infinite Scale Users Light. +
-From now on, the application supports Infinite Scale Users Light (those who don't have personal space). All the functionalities have been adapted to allow this type of users to use the application correctly, taking into account all their limitations.
+From now on, the application supports Infinite Scale Users Light (those who don't have personal space). All the functionalities have been adapted to allow this type of user to use the application correctly, taking into account all their limitations.
 
 * Added text labels on bottom bar. +
 Text labels have been added to all the items that appear in the bottom navigation bar to provide enough and clear information about the available sections that we have.


### PR DESCRIPTION
Adding Android 4.5.0 Release Notes, derived from the Android repo and Central.

Tested locally, renders fine.