### PR TITLE
docs: fix accessing the correct ocis module

### DIFF
--- a/modules/ROOT/pages/ocis_release_notes.adoc
+++ b/modules/ROOT/pages/ocis_release_notes.adoc
@@ -348,7 +348,7 @@ For configuration details see: xref:next@ocis:ROOT:deployment/services/env-var-c
 
 * The OCM service (federated sharing, ScienceMesh) got productivity improvements.
 
-* The compose based deployment examples got updated images. See the xref:next@ocis:ROOT:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#updating-and-upgrading[Updating and Upgrading] compose example description for more details.
+* The compose based deployment examples got updated images. See the xref:next@ocis:admin:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#updating-and-upgrading[Updating and Upgrading] compose example description for more details.
 
 [discrete]
 === Deprecations
@@ -444,7 +444,7 @@ It connects with web office document servers such as Collabora, ONLYOFFICE or Mi
 When using external services like an IDP, web office document servers or web apps (like provided in our docker compose deployment examples), a Content Security Policy (CSP) has been implemented to secure the environment. For details on web office/apps see the next list item. For details on CSP see xref:breaking-changes[Breaking Changes] section.
 
 * Fully customisable deployment examples ready for production use including web office, based on docker compose. See
-xref:next@ocis:ROOT:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] and xref:next@ocis:ROOT:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner]. +
+xref:next@ocis:admin:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] and xref:next@ocis:admin:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner]. +
 Note that with these examples, you can easily enable additional web apps like `draw-io`, `external-sites`, `json-viewer`, `unzip`, `progressbars` and others. +
 Though provided via the compose example setup, no support can be given for these web apps.
 


### PR DESCRIPTION
This PR fixes the access to the correct ocis module after the change added in:
https://github.com/owncloud/docs-ocis/pull/1249 (docs: prepare to include developer docs)

`next@ocis:ROOT:` --> `next@ocis:admin:`

With that, used ocis links are properly resolved again.