### PR TITLE
feat: add Desktop App 7.1.0 release notes

### DIFF
--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -14,6 +14,21 @@
 
 toc::[]
 
+== Desktop App 7.1.0
+
+[discrete]
+=== General
+
+The ownCloud Desktop App is now available in version 7.1.0! +
+We strongly recommend updating the Desktop App to the latest available version so that you can access and experience a range of new features and security fixes. Users with an Enterprise subscription are entitled to receive dedicated support.
+
+Refer to the full change log for a list of bug fixes and changes at {desktop-releases-url}v7.1.0[GitHub, window=_blank].
+
+[NOTE]
+====
+There is no public *Desktop App 7.0* release. Version 7.0 was produced as an internal-only build used for cross-team integration and release-process validation, and was never published to end users. The 7.x line debuts publicly with 7.1.0, which is why the version history jumps directly from 6.0.x to 7.1.0.
+====
+
 == Desktop App 6.0.3
 
 [discrete]

--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -24,6 +24,11 @@ We strongly recommend updating the Desktop App to the latest available version s
 
 Refer to the full change log for a list of bug fixes and changes at {desktop-releases-url}v7.1.0[GitHub, window=_blank].
 
+[IMPORTANT]
+====
+The Desktop App 7 series supports *ownCloud Infinite Scale (oCIS)* only. If you are using ownCloud Classic (Server) version 10 or 11, you must stay on the Desktop App 6 series. Do not upgrade to the 7 series until you have migrated to Infinite Scale.
+====
+
 [NOTE]
 ====
 There is no public *Desktop App 7.0* release. Version 7.0 was produced as an internal-only build used for cross-team integration and release-process validation, and was never published to end users. The 7.x line debuts publicly with 7.1.0, which is why the version history jumps directly from 6.0.x to 7.1.0.


### PR DESCRIPTION
Adds the **Desktop App 7.1.0** release notes entry, coinciding with the desktop docs 7.1
version going live (see owncloud/docs#5107 and owncloud/docs-client-desktop#720).

### Changes
- New `== Desktop App 7.1.0` section at the top of `desktop_release_notes.adoc`, following the
  existing per-version format (General + GitHub changelog link).
- A `NOTE` admonition documenting that **there is no public 7.0 release** — 7.0 was an
  internal-only build used for cross-team integration and release-process validation, so the
  public 7.x line starts at 7.1.0. This explains the version jump from 6.0.x to 7.1.0.

### Verification
- Built locally with `npm run antora-local` (Node 22): exit 0, no errors referencing
  `desktop_release_notes.adoc`. The pre-existing cross-component xref errors in
  `client_releases.adoc`/`index.adoc` are expected in the standalone test build
  (`failure_level: none`) and unrelated to this change.
- Confirmed the 7.1.0 entry and the 7.0 note render correctly in `public/desktop_release_notes.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
