### PR TITLE
docs: add Notable Changes to Desktop App 7.1.0 release notes

### DIFF
--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -43,7 +43,7 @@ There is no public *Desktop App 7.0* release. Version 7.0 was produced as an int
 * Change: Remove the suffix VFS plugin: https://github.com/owncloud/client/pull/12174[#12174]
 * Change: Remove the capability to upload conflict files: https://github.com/owncloud/client/pull/12369[#12369]
 * Change: Remove the activity tab from account settings: https://github.com/owncloud/client/pull/12307[#12307]
-* Change: MacOS 13 is now the minimum supported macOS version: https://github.com/owncloud/client/pull/12245[#12245]
+* Change: macOS 13 is now the minimum supported macOS version: https://github.com/owncloud/client/pull/12245[#12245]
 * Change: Qt 6.8 is now the minimum required Qt version: https://github.com/owncloud/client/pull/12270[#12270]
 * Enhancement: New account setup wizard: https://github.com/owncloud/client/pull/12189[#12189]
 * Enhancement: System-based configuration (group policy support): https://github.com/owncloud/client/pull/12367[#12367]

--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -34,6 +34,21 @@ The Desktop App 7 series supports *ownCloud Infinite Scale (oCIS)* only. If you 
 There is no public *Desktop App 7.0* release. Version 7.0 was produced as an internal-only build used for cross-team integration and release-process validation, and was never published to end users. The 7.x line debuts publicly with 7.1.0, which is why the version history jumps directly from 6.0.x to 7.1.0.
 ====
 
+[discrete]
+=== Notable Changes
+
+* Change: Remove support for ownCloud Server (OC10); the client now requires ownCloud Infinite Scale: https://github.com/owncloud/client/pull/12167[#12167]
+* Change: Remove the command line sync client: https://github.com/owncloud/client/pull/12162[#12162]
+* Change: Remove bandwidth throttling controls: https://github.com/owncloud/client/pull/12335[#12335]
+* Change: Remove the suffix VFS plugin: https://github.com/owncloud/client/pull/12174[#12174]
+* Change: Remove the capability to upload conflict files: https://github.com/owncloud/client/pull/12369[#12369]
+* Change: Remove the activity tab from account settings: https://github.com/owncloud/client/pull/12307[#12307]
+* Change: MacOS 13 is now the minimum supported macOS version: https://github.com/owncloud/client/pull/12245[#12245]
+* Change: Qt 6.8 is now the minimum required Qt version: https://github.com/owncloud/client/pull/12270[#12270]
+* Enhancement: New account setup wizard: https://github.com/owncloud/client/pull/12189[#12189]
+* Enhancement: System-based configuration (group policy support): https://github.com/owncloud/client/pull/12367[#12367]
+* Enhancement: Redesigned account and folder management view: https://github.com/owncloud/client/pull/12399[#12399]
+
 == Desktop App 6.0.3
 
 [discrete]


### PR DESCRIPTION
Follow-up to #178 (merged), addressing the review feedback from review `4526651338`.

Adds a **`Notable Changes`** subsection to the Desktop App 7.1.0 release-notes entry, matching the
format of the existing 6.0.x entries. The original 7.1.0 entry had only the General paragraph and
GitHub changelog link; this surfaces the items users need to know before upgrading.

### Notable Changes (verified against `owncloud/client` `CHANGELOG.md@v7.1.0`)
Breaking removals first, then raised platform minimums, then UX enhancements:
- Remove support for ownCloud Server (OC10) — client now requires Infinite Scale (#12167)
- Remove the command-line sync client (#12162)
- Remove bandwidth throttling controls (#12335)
- Remove the suffix VFS plugin (#12174)
- Remove the capability to upload conflict files (#12369)
- Remove the activity tab from account settings (#12307)
- macOS 13 minimum (#12245); Qt 6.8 minimum (#12270)
- New account setup wizard (#12189); group-policy / system-based configuration (#12367); redesigned account & folder management view (#12399)

### Notes on the other review points
- The "version 10 or 11" wording in the IMPORTANT note is intentionally kept as-is.
- "security fixes" boilerplate in General left unchanged — consistent with the rest of the file.

### Verification
Built locally with `npm run antora-local` (Node 22): exit 0, no log lines referencing
`desktop_release_notes.adoc`. Confirmed all 11 bullets and their PR links render under 7.1.0,
above 6.0.3, with admonitions intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
