### PR TITLE
chore(deps): drop unused direct dependency lodash

### DIFF
--- a/ext-antora/generate-index.js
+++ b/ext-antora/generate-index.js
@@ -2,7 +2,6 @@
 
 // Antora extension to create a new and clean search index based on ElasticSearch
 
-const _ = require('lodash')
 const cheerio = require('cheerio')
 const Entities = require('html-entities')
 const { Client } = require('@elastic/elasticsearch')

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "asciidoctor-kroki": "^0.18.1",
         "cheerio": "^1.2.0",
         "html-entities": "2.6.0",
-        "js-yaml": "^5.0.0",
-        "lodash": "^4.18.1"
+        "js-yaml": "^5.0.0"
       },
       "devDependencies": {
         "broken-link-checker": "^0.7.8",
@@ -2320,12 +2319,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "asciidoctor-kroki": "^0.18.1",
     "cheerio": "^1.2.0",
     "html-entities": "2.6.0",
-    "js-yaml": "^5.0.0",
-    "lodash": "^4.18.1"
+    "js-yaml": "^5.0.0"
   },
   "devDependencies": {
     "broken-link-checker": "^0.7.8",


### PR DESCRIPTION
## What

Removes the `lodash` direct dependency and its stray import in `ext-antora/generate-index.js`.

## Why

`lodash` is declared as a direct dependency and imported at `ext-antora/generate-index.js:5` (`const _ = require('lodash')`), but it is **never used**. There is no `_.` call anywhere in that file or the rest of the repo — the only `_` occurrences are in comments (e.g. a `// Q: use _.difference(...)` note) and string literals (`_index`, `_email-config.adoc`).

This is a follow-up to #182 (dropping the unused `asciidoctor` dep). A full re-audit of the remaining dependencies — confirmed independently by a second pass — found `lodash` as the only other removable one; all 7 others (`@elastic/elasticsearch`, `antora`, `asciidoctor-kroki`, `cheerio`, `html-entities`, `js-yaml`, plus dev deps `broken-link-checker`, `http-server`) are genuinely used.

## Changes

- `ext-antora/generate-index.js` — remove the unused `require('lodash')` import.
- `package.json` — remove `"lodash": "^4.18.1"` from `dependencies`.
- `package-lock.json` — regenerated; `lodash` has no transitive deps, so only its own entry is dropped.

## Verification

- `grep -rn "lodash\|_\." ext-antora ext-asciidoc` → only a comment remains, no real usage.
- Loading the extension no longer references lodash (it now reaches the `cheerio` require, past the old line 5).
- `package-lock.json` no longer contains a `node_modules/lodash` entry.

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)