### PR TITLE
docs: drop redundant version from "ownCloud Classic 10"

### DIFF
--- a/modules/ROOT/pages/desktop_release_notes.adoc
+++ b/modules/ROOT/pages/desktop_release_notes.adoc
@@ -149,9 +149,9 @@ IMPORTANT: This release is the last one that supports ownCloud Classic 10.
 
 The following is a list of known issues identified in the Desktop App that will be fixed in a subsequent patch release:
 
-* **Affects sync relationshipts to ownCloud Classic 10 only**: +
+* **Affects sync relationshipts to ownCloud Classic only**: +
 After upgrading to version 6.0.0 of the Desktop App, files containing special characters, such as umlauts (ä, ö, and ü), will be deleted by the app.
-** If you are using ownCloud Classic 10 and have special characters in your file names:
+** If you are using ownCloud Classic and have special characters in your file names:
 *** Wait to install until version 6.0.1 of the Desktop App is released.
 *** If you have already upgraded and are affected: +
 Revert to the previous version of the Desktop App and restore the missing files from the user's Trash Bin in the ownCloud GUI.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -32,7 +32,7 @@ Infinite Scale comes with a ramped-up WOPI protocol server that provides collabo
 
 === Links
 
-In Infinite Scale, we drastically simplified sharing by links. First of all: You can get a link with a single click in ownCloud Web. Second: You can share one and the same link with internal and external people at once, and if you change your mind, you can restrict access, for example, to only internal people of your organization. This feature was known as "private link" in ownCloud Classic 10 and is still available but via the "internal" selection of a link.
+In Infinite Scale, we drastically simplified sharing by links. First of all: You can get a link with a single click in ownCloud Web. Second: You can share one and the same link with internal and external people at once, and if you change your mind, you can restrict access, for example, to only internal people of your organization. This feature was known as "private link" in ownCloud Classic and is still available but via the "internal" selection of a link.
 
 === Cloud Native Deployments
 
@@ -64,8 +64,8 @@ With that, Infinite Scale provides a deployment model for modern cloud infrastru
 | S3
 | “s3ng” driver; with decomposedfs for metadata (POSIX)
 
-| ownCloud Classic 10 SQL storage driver
-| Needed for parallel deployments with ownCloud Classic 10 and for migration purposes
+| ownCloud Classic SQL storage driver
+| Needed for parallel deployments with ownCloud Classic and for migration purposes
                                      
 .4+| Users & IDM
 | Integrated, lightweight user & group management (LibreIDM)
@@ -127,10 +127,10 @@ With that, Infinite Scale provides a deployment model for modern cloud infrastru
 
 .3+| API & Integration
 | WebDAV
-| API for file operations; API endpoints known from ownCloud Classic 10
+| API for file operations; API endpoints known from ownCloud Classic
 
 | OCS
-| Open Collaboration Services, ownCloud-specific API endpoints known from ownCloud Classic 10
+| Open Collaboration Services, ownCloud-specific API endpoints known from ownCloud Classic
 
 | LibreGraph
 | Open implementation of the MS Graph API, currently used for the management of spaces

--- a/modules/ROOT/pages/ocis_historic_rn.adoc
+++ b/modules/ROOT/pages/ocis_historic_rn.adoc
@@ -205,7 +205,7 @@ Refer to the source and the full change log for a list of bug fixes and changes 
 [discrete]
 === Permanent Link
 
-You can now copy links even more easily: As soon as you have shared a file with someone else, you can now just click on copy "Permanent Link". This link allows you to share direct links with people who already have access and enables users to jump straight to the desired file, improving navigation efficiency. Simply copy and share the link to access specific files instantly. (For those who are familiar with the PHP based ownCloud Classic 10: The permanent link in Infinite Scale has the same function as "Private Links" in ownCloud Classic 10)
+You can now copy links even more easily: As soon as you have shared a file with someone else, you can now just click on copy "Permanent Link". This link allows you to share direct links with people who already have access and enables users to jump straight to the desired file, improving navigation efficiency. Simply copy and share the link to access specific files instantly. (For those who are familiar with the PHP based ownCloud Classic: The permanent link in Infinite Scale has the same function as "Private Links" in ownCloud Classic)
 
 [discrete]
 === New App: Link to External Sites
@@ -1219,7 +1219,7 @@ For example, if you're looking for a particular project file and you remember ta
 [discrete]
 === Cloud Importer (experimental)
 
-We are excited to announce our new extension: Cloud Importer, designed to import files from other services. With this functionality, you can now seamlessly import files and folders from other services like OneDrive, Google Drive, ownCloud Classic 10 or Nextcloud directly into Infinite Scale.
+We are excited to announce our new extension: Cloud Importer, designed to import files from other services. With this functionality, you can now seamlessly import files and folders from other services like OneDrive, Google Drive, ownCloud Classic or Nextcloud directly into Infinite Scale.
 
 Effortlessly transfer your work documents, shared files, or entire project folders from these popular cloud storage platforms to your account. Whether you're moving a single document or a large batch of files, the Cloud Importer ensures a smooth, fast, and reliable transfer. Note that the Cloud Importer only imports files, not shares or tags. Think of it as uploading a file, but from a cloud service instead of from your local drive.
 
@@ -1832,7 +1832,7 @@ Version 1.19.0 brings major improvements, new features and bug fixes to the plat
 The most prominent changes in Infinite Scale 1.19.0 and ownCloud Web 5.3.0 comprise:
 
 * Bugfix - Thumbnails only for accepted shares: https://github.com/owncloud/web/issues/5310[#5310]
-* Bugfix - Show no auth popup on password-protected public links in ownCloud Classic 10: https://github.com/owncloud/web/pull/6530[#6530]
+* Bugfix - Show no auth popup on password-protected public links in ownCloud Classic: https://github.com/owncloud/web/pull/6530[#6530]
 * Bugfix - Prevent cross-site scripting attack while displaying space description: https://github.com/owncloud/web/pull/6523[#6523]
 * Bugfix - Replace public mountpoint fileid with grant fileid in ocdav: https://github.com/cs3org/reva/pull/2646[cs3org/reva#2646]
 * Change - Switch NATS backend: https://github.com/cs3org/reva/pull/2574[cs3org/reva#2574]
@@ -1911,7 +1911,7 @@ The most prominent changes in Infinite Scale 1.18.0 and ownCloud Web 5.2.0 compr
 
 * The endpoint to list Spaces now supports sorting by name and last modification time. https://github.com/owncloud/ocis/pull/3201[ocis#3201]
 
-* The Search feature in ownCloud Web has been fixed and improved, e.g., the context menu works again properly (only available on ownCloud Classic 10 currently). https://github.com/owncloud/web/pull/6445[web#6445],  https://github.com/owncloud/web/issues/6496[web#6496]
+* The Search feature in ownCloud Web has been fixed and improved, e.g., the context menu works again properly (only available on ownCloud Classic currently). https://github.com/owncloud/web/pull/6445[web#6445],  https://github.com/owncloud/web/issues/6496[web#6496]
 
 * Creating a new file now refreshes the file list in ownCloud Web. https://github.com/owncloud/web/issues/5530[web#5530]
 
@@ -1931,7 +1931,7 @@ IMPORTANT: We are currently in a Tech Preview state and breaking changes may occ
 [discrete]
 === Infinite Scale 1.17.0 Technology Preview
 
-Version 1.17.0 brings major changes, new features and improvements. The Infinite Scale backend introduces an event system as an important platform component and adds support for file locking. ownCloud Web 5.0.0 comes with a full rework of the design and user experience and introduces initial support for the `Spaces` feature. Additionally ownCloud Web now supports Collabora Online with the ownCloud Classic 10 backend.
+Version 1.17.0 brings major changes, new features and improvements. The Infinite Scale backend introduces an event system as an important platform component and adds support for file locking. ownCloud Web 5.0.0 comes with a full rework of the design and user experience and introduces initial support for the `Spaces` feature. Additionally ownCloud Web now supports Collabora Online with the ownCloud Classic backend.
 
 The most prominent changes in Infinite Scale 1.17.0 and ownCloud Web 5.0.0 comprise:
 
@@ -1951,9 +1951,9 @@ The most prominent changes in Infinite Scale 1.17.0 and ownCloud Web 5.0.0 compr
 
 * ownCloud Web now provides an ID- and path-based URL scheme according to https://owncloud.dev/ocis/adr/0011-global-url-format/#mixed-global-urls[mixed global url's]. https://github.com/owncloud/web/pull/6137[web#6137]
 
-* ownCloud Web now supports Collabora Online with the ownCloud Classic 10 backend. More information on configuration can be found in the https://owncloud.dev/clients/web/deployments/oc10-app/#collabora-online[documentation].
+* ownCloud Web now supports Collabora Online with the ownCloud Classic backend. More information on configuration can be found in the https://owncloud.dev/clients/web/deployments/oc10-app/#collabora-online[documentation].
 
-* ownCloud Web now respects share expiration date enforcement and defaults with the ownCloud Classic 10 backend. https://github.com/owncloud/web/pull/6176[web#6176]
+* ownCloud Web now respects share expiration date enforcement and defaults with the ownCloud Classic backend. https://github.com/owncloud/web/pull/6176[web#6176]
 
 * The People sharing dialog in ownCloud Web has received a couple of improvements. https://github.com/owncloud/web/pull/6039[web#6039]
 
@@ -2602,7 +2602,7 @@ Infinite Scale is following the microservices architectural pattern. It is imple
 
 * Native storage capabilities are used where like native versioning and trashbin
 
-* Public APIs like WebDAV and OCS have been kept compatible with ownCloud Classic 10
+* Public APIs like WebDAV and OCS have been kept compatible with ownCloud Classic
 
 * A secure and flexible framework to create extensions
 
@@ -2650,9 +2650,9 @@ In standalone mode oCIS uses its built-in orchestrator to start all necessary se
 oCIS allows you to scale individual services using well-known orchestration frameworks like docker-compose, dockerSwarm and kubernetes.
 
 [discrete]
-===== Bridge mode with ownCloud Classic 10 backend
+===== Bridge mode with ownCloud Classic backend
 
-For the product transition phase, Infinite Scale comes with an operation mode ("bridge mode") that allows a hybrid deployment between both server generations to operate the new web frontend with ownCloud Classic 10 and Infinite Scale in parallel. This setup allows the ownCloud Web frontend to operate with both server generations and provides the foundation to migrate users gradually to the new backend.
+For the product transition phase, Infinite Scale comes with an operation mode ("bridge mode") that allows a hybrid deployment between both server generations to operate the new web frontend with ownCloud Classic and Infinite Scale in parallel. This setup allows the ownCloud Web frontend to operate with both server generations and provides the foundation to migrate users gradually to the new backend.
 
 **Requirements for the bridge mode**
 
@@ -2685,7 +2685,7 @@ One of the most important objectives for oCIS was to ease the setup of a working
 [discrete]
 ===== Deployment Options
 
-Given the architecture of Infinite Scale, there are various deployment options based on the users requirements. In our experience setting up the LAMP stack for ownCloud Classic 10 was difficult for many users. Therefore a big emphasis was put on easy yet functional https://owncloud.dev/ocis/deployment/[deployment] strategies.
+Given the architecture of Infinite Scale, there are various deployment options based on the users requirements. In our experience setting up the LAMP stack for ownCloud Classic was difficult for many users. Therefore a big emphasis was put on easy yet functional https://owncloud.dev/ocis/deployment/[deployment] strategies.
 
 [discrete]
 ===== Delivery as single binary
@@ -2793,7 +2793,7 @@ For more sophisticated setups we recommend using one of our docker setup example
 
 * Display basic profile information (user name, display name, e-mail, group memberships)
 
-* "Edit" button guides to ownCloud Classic 10 user settings (when used with oC 10)
+* "Edit" button guides to ownCloud Classic user settings (when used with oC 10)
 
 [discrete]
 ====== Basic user settings

--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -340,7 +340,7 @@ Dear ownCloud administrator, find below the changes and known issues in ownCloud
 
 We now display IoC scanner instructions to all customers (a valid license key needs to be present) during upgrade (console as well as Web Updater) and in the admin settings. https://github.com/owncloud/core/pull/41137[#41137]
 
-Background: The Indicators of Compromise (IoC) tool plays a vital role in identifying potential security threats or breaches. The tool analyzes your ownCloud Classic 10 deployments and determines whether they have possibly been compromised via the known vulnerabilities. It collects information from the Apache logs and identifies the signatures of potential exploits. Please note, the tool has to be run on ALL ownCloud servers in case of a clustered setup!
+Background: The Indicators of Compromise (IoC) tool plays a vital role in identifying potential security threats or breaches. The tool analyzes your ownCloud Classic deployments and determines whether they have possibly been compromised via the known vulnerabilities. It collects information from the Apache logs and identifies the signatures of potential exploits. Please note, the tool has to be run on ALL ownCloud servers in case of a clustered setup!
 
 [discrete]
 === 2FA Check on Controllers Which Are Annotated as @PublicPage and Also Authenticated
@@ -1169,7 +1169,7 @@ Dear ownCloud administrator, please find below the changes and known issues in o
 [discrete]
 === ownCloud Web supplements the Classic Web Interface - Try it!
 
-The all-new web interface for ownCloud, ownCloud Web, has come a long way since its initial release at the end of 2020. It is available as an app on the https://marketplace.owncloud.com/apps/web[ownCloud Marketplace] and ownCloud Classic has been xref:server_release_notes.adoc#owncloud-web-the-new-web-frontend-for-owncloud[prepared to work with it since version 10.6]. ownCloud Web https://owncloud.dev/clients/web/deployments/oc10-app/#configure-owncloud-10[can be deployed as a supplement to the classic web interface] and meanwhile it is in use at quite a number of installations. This has brought up good feedback around the integration with ownCloud Classic 10 that has been addressed for 10.8. Additionally, lots of improvements have made their way into ownCloud Web. For an overview you can have a look at the https://owncloud.dev/ocis/release_notes/[ownCloud Infinite Scale release notes] and for a full list of changes, please see the https://github.com/owncloud/web/blob/master/CHANGELOG.md[ownCloud Web changelog].
+The all-new web interface for ownCloud, ownCloud Web, has come a long way since its initial release at the end of 2020. It is available as an app on the https://marketplace.owncloud.com/apps/web[ownCloud Marketplace] and ownCloud Classic has been xref:server_release_notes.adoc#owncloud-web-the-new-web-frontend-for-owncloud[prepared to work with it since version 10.6]. ownCloud Web https://owncloud.dev/clients/web/deployments/oc10-app/#configure-owncloud-10[can be deployed as a supplement to the classic web interface] and meanwhile it is in use at quite a number of installations. This has brought up good feedback around the integration with ownCloud Classic that has been addressed for 10.8. Additionally, lots of improvements have made their way into ownCloud Web. For an overview you can have a look at the https://owncloud.dev/ocis/release_notes/[ownCloud Infinite Scale release notes] and for a full list of changes, please see the https://github.com/owncloud/web/blob/master/CHANGELOG.md[ownCloud Web changelog].
 
 The most prominent recent improvements are
 
@@ -1406,13 +1406,13 @@ in ownCloud Web.
 
 There are different ways to deploy ownCloud Web with ownCloud Classic. We strive to make it as easy as
 possible to make the new frontend available to users. For this, there is the new app for
-{oc-marketplace-url}/apps/web[Web] on the ownCloud Marketplace. It can be installed on ownCloud Classic 10 servers with
+{oc-marketplace-url}/apps/web[Web] on the ownCloud Marketplace. It can be installed on ownCloud Classic servers with
 the regular tools. The app will make the new frontend available as described above when
 https://owncloud.github.io/clients/web/deployments/oc10-app/[deployed and configured correctly].
 
 TIP: Deploying ownCloud Web via the Marketplace app is the currently recommended approach.
 
-**Requirements for deploying ownCloud Web as an app for ownCloud Classic 10**
+**Requirements for deploying ownCloud Web as an app for ownCloud Classic**
 
 * ownCloud Classic 10.6
 * {oc-marketplace-url}/apps/oauth2[OAuth2] or {oc-marketplace-url}/apps/openidconnect[OpenID Connect]
@@ -2028,7 +2028,7 @@ Please be aware that apps that do not support outdated PHP versions will not upg
 TIP: See the xref:server:admin_manual:installation/system_requirements.adoc#officially-supported-environments[system requirements in the ownCloud documentation].
 
 To allow for additional upgrade time, version 10.2 still supports PHP 7.0, because some of the major Linux distributions continue to support it.
-However, support for PHP 7.0 will be discontinued in an upcoming version of ownCloud Classic 10, to enhance both security and performance.
+However, support for PHP 7.0 will be discontinued in an upcoming version of ownCloud Classic, to enhance both security and performance.
 To prepare for this change, we strongly encourage you to begin planning an upgrade as soon as possible.
 
 [discrete]
@@ -2857,7 +2857,7 @@ extension (_admin_audit_) is required.
 [discrete]
 === New command to verify and repair file checksums
 
-With ownCloud Classic 10 file integrity checking by computing and matching
+With ownCloud Classic file integrity checking by computing and matching
 checksums has been introduced to ensure that transferred files arrive at
 their target in the exact state as their origin. In some rare cases
 wrong checksums can be written to the database leading to
@@ -2887,7 +2887,7 @@ needs best.
 [discrete]
 === New option to granularly configure public link password enforcement
 
-With ownCloud Classic 10 the `File Drop` feature has been merged with public
+With ownCloud Classic the `File Drop` feature has been merged with public
 link permissions. This kind of public link does not give recipients
 access to any content, but it gives them the possibility to `drop
 files`. As a result, it might not always be desirable to enforce
@@ -3221,7 +3221,7 @@ to be able to use the feature with ownCloud Classic 10.0.4.
 * https://github.com/owncloud/core/issues/29156[SFTP external storages with key pair mode work again]
 * https://github.com/owncloud/core/issues/29240[Added support for MariaDB 10.2.7+]
 * https://github.com/owncloud/core/issues/29049[Encryption panel in admin settings fixed to
-properly detect current mode after upgrade to ownCloud Classic 10]
+properly detect current mode after upgrade to ownCloud Classic]
 * https://github.com/owncloud/core/pull/29261[Removed double quotes from boolean values in status.php output]
 
 == Changes in 10.0.3


### PR DESCRIPTION
## What

Follow-up to the "ownCloud Classic" rename (#187): the canonical product name is **ownCloud Classic** with no trailing version, so this strips the now-redundant `10` from bare `ownCloud Classic 10` references.

## Kept intentionally

- Specific release references keep their version: `ownCloud Classic 10.16.3`, `10.8`, etc.
- The **`ownCloud Classic 11`** milestone is left as-is — the version is meaningful there (Docker-only deployment, API deprecation), and is handled contextually in the version-specific manuals rather than blindly stripped.

## Out of scope (unchanged)

`xref`/`include` targets, module slugs, URLs (`oc10-app`), and **ownCloud Infinite Scale** / **oCIS** references.

## Verification

- 0 residual bare `ownCloud Classic 10`; dotted release versions preserved (124 in `server_release_notes.adoc`).
- Every URL/xref target byte-for-byte identical.
- Spot-checked that sentences still read correctly after the version removal (e.g. bridge-mode parallel-deployment text retains its "both server generations" contrast).

Part of owncloud/docs#5111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
