### PR TITLE
docs: add server release notes for 10.16.4

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -17,6 +17,20 @@ next@docs::server_release_notes.adoc, next@docs_main::server_release_notes.adoc
 toc::[]
 
 
+== Changes in 10.16.4
+
+Dear ownCloud administrator, find below the changes and known issues in ownCloud Classic 10.16.4 that need your attention. You can also read the {oc-changelog-url}[full ownCloud Classic changelog] for further details on what has changed.
+
+IMPORTANT: This is a security release. Upgrading is strongly recommended for all installations.
+
+[discrete]
+=== Security Fixes
+
+* Honour the write hook veto on legacy chunked WebDAV uploads: https://github.com/owncloud/core/pull/41763[#41763] +
+The legacy WebDAV chunked upload path assembled the final file without respecting the pre-write hook result, so the filename blacklist that applies to ordinary uploads was not enforced for chunked uploads. A file name that is rejected on the normal upload path could still be written through the chunked path.
+* Fix subadmin email change updating caller's address instead of target's: https://github.com/owncloud/core/pull/41574[#41574] +
+The verification token and confirmation link in the subadmin path of `setMailAddress` were associated with the caller's account instead of the target user's account.
+
 == Changes in 10.16.3
 
 Dear ownCloud administrator, find below the changes and known issues in ownCloud Classic 10.16.3 that need your attention. You can also read the {oc-changelog-url}[full ownCloud Classic changelog] for further details on what has changed.


### PR DESCRIPTION
## Summary

Add release notes for **ownCloud Classic 10.16.4**, [published 2026-07-29](https://github.com/owncloud/core/releases/tag/v10.16.4). The page previously stopped at 10.16.3, so admins had no rendered page telling them what changed or that they should upgrade.

10.16.4 is a **security release**. It carries a critical fix for the legacy chunked WebDAV upload path, which assembled the final file without honouring the pre-write hook veto — so the filename blacklist enforced on ordinary uploads was bypassable via chunking.

## Changes

`modules/ROOT/pages/server_release_notes.adoc` — new `== Changes in 10.16.4` section inserted above 10.16.3 (newest first), covering owncloud/core#41763 and owncloud/core#41574.

## Notes on style

- Uses a flat `=== Security Fixes` list rather than the nested `* Security:` / `* Bugfix:` grouping of the 10.16.3 block. That nesting exists because 10.16.3 had six entries across categories; with two entries the flat form (same shape as the 10.16.1 and 10.15.2 blocks in this file) reads better.
- The GHSA advisory IDs are deliberately **not** linked — both are still `triage`/`draft`, so their URLs 404 for the public. PR links are what this file uses throughout.

## Verification

Rendered locally with asciidoctor — no warnings or errors. Confirmed in the output HTML:

- `<h2 id="_changes_in_10_16_4">` appears **before** `_changes_in_10_16_3`
- the `IMPORTANT` admonition renders as `admonitionblock important`
- `=== Security Fixes` renders as a `[discrete]` `<h3>` (excluded from the TOC, as intended)
- all three links resolve, and `{oc-changelog-url}` is substituted correctly
- the `+` line continuations keep each description attached to its bullet

## Related

- owncloud/docs#5140 and owncloud/docs-server#1574 — bump `latest-server-download-version` to 10.16.4
- owncloud/core#41766 — forward-port the 10.16.4 changelog to core `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
