### PR TITLE
docs: drop references to the next server version

### DIFF
--- a/modules/ROOT/pages/server_release_notes.adoc
+++ b/modules/ROOT/pages/server_release_notes.adoc
@@ -1245,7 +1245,7 @@ All xref:server_release_notes.adoc#known-issues-10-8[known issues in Server 10.8
 
 * When updating an existing instance to ownCloud Classic 10.9, you may experience that the marketplace is not accessible via ownCloud and content is not shown. If you have this issue, see the following link for details and a https://github.com/owncloud/core/issues/39616#issuecomment-1001490469[procedure how to solve] this.
 
-* If you use encryption, we recommend _not to update_ to ownCloud Classic 10.9.0 but wait until 10.9.1 will be released in early January 2022. The following issue can occur: If you have an encrypted file which is shared, the file gets corrupted if the share recipient overwrites that file. This means that the latest changes will be lost. If  https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_versioning.html[Files Versions] has been enabled, you can restore the previous version. The issue has been resolved already and will be available with the next patch release. See the following link for https://github.com/owncloud/core/pull/39623[more technical details].
+* If you use encryption, we recommend _not to update_ to ownCloud Classic 10.9.0 but wait until 10.9.1 will be released in early January 2022. The following issue can occur: If you have an encrypted file which is shared, the file gets corrupted if the share recipient overwrites that file. This means that the latest changes will be lost. If  https://doc.owncloud.com/server/latest/admin_manual/configuration/files/file_versioning.html[Files Versions] has been enabled, you can restore the previous version. The issue has been resolved already and will be available with the next patch release. See the following link for https://github.com/owncloud/core/pull/39623[more technical details].
 
 == Changes in 10.8.0
 
@@ -1803,10 +1803,10 @@ Server 10.4 is thoroughly tested against these database versions and proven to w
 [discrete]
 === For Developers
 
-* The xref:next@server:developer_manual:webdav_api/trashbin.adoc[WebDAV Trash bin API] and the xref:next@server:developer_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links] (introduced with 10.3.0) have left the tech preview state.
+* The xref:server:developer_manual:webdav_api/trashbin.adoc[WebDAV Trash bin API] and the xref:server:developer_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links] (introduced with 10.3.0) have left the tech preview state.
   They are considered stable and are enabled by default.
 * The config.php option to enable/disable tech preview APIs (`'dav.enable.tech_preview' => true`) has been removed as it's obsolete. https://github.com/owncloud/core/pull/36815[#36815]
-* A new xref:next@server:developer_manual:core/apis/ocs-user-sync-api.adoc[OCS User Sync API] to trigger user sync from external user backends has been added.
+* A new xref:server:developer_manual:core/apis/ocs-user-sync-api.adoc[OCS User Sync API] to trigger user sync from external user backends has been added.
   This allows external user provisioning systems to push new users to ownCloud on demand and removes the necessity to do full user sync. https://github.com/owncloud/core/pull/36428[#36428]
 
 [#known-issues-10-4]
@@ -1977,9 +1977,9 @@ As Phoenix is separated from the backend and communicates only via HTTP APIs, it
 
 The following new HTTP APIs have been added with Server 10.3:
 
-* xref:next@server:developer_manual:webdav_api/trashbin.adoc[WebDAV Trash bin API].
-* xref:next@server:developer_manual:core/apis/ocs-notify-public-link-by-email.adoc[OCS API for public link share email notifications]
-* xref:next@server:developer_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links].
+* xref:server:developer_manual:webdav_api/trashbin.adoc[WebDAV Trash bin API].
+* xref:server:developer_manual:core/apis/ocs-notify-public-link-by-email.adoc[OCS API for public link share email notifications]
+* xref:server:developer_manual:webdav_api/public_files.adoc[WebDAV endpoint for public links].
 
 All new endpoints are currently in tech preview state and are mainly used for Phoenix development.
 For this reason, they are disabled by default and have to be explicitly enabled using the new config.php option: `'dav.enable.tech_preview' => true,`.
@@ -2036,7 +2036,7 @@ For this reason, they are disabled by default and have to be explicitly enabled 
 * The theming capabilities have been improved by allowing HTML for `Name` and `LogoClaim`.
   Please check https://github.com/owncloud/theme-example/pull/7/files[the changes to owncloud/theme-example] if you are interested in making use of this in your theme. https://github.com/owncloud/core/pull/35273[#35273]
 * A new Roles API has been added to allow clients to query the server for available permissions/roles for user/group sharing and public links.
-  In future client releases, this endpoint will be used to dynamically display roles/permissions depending on the server's capabilities. You can find out more about it in xref:next@server:developer_manual:core/apis/roles-api.adoc[the Roles API documentation].
+  In future client releases, this endpoint will be used to dynamically display roles/permissions depending on the server's capabilities. You can find out more about it in xref:server:developer_manual:core/apis/roles-api.adoc[the Roles API documentation].
 * A new, improved version of the "_Advanced Sharing Permissions_" JavaScript API (v2) has been added to allow ownCloud apps to register additional permissions/restrictions in user/group sharing.
   Version 1 of the API is still available in parallel. https://github.com/owncloud/core/pull/35836[#35863]
 
@@ -3617,14 +3617,14 @@ development around webdav
 
 * PSR-4 autoloading forced for `OC\` and `OCP\`, optional for `OCA\`
 docs at
-xref:next@server:developer_manual:app/fundamentals/classloader.adoc
+xref:server:developer_manual:app/fundamentals/classloader.adoc
 * More cleanup of the sharing code (ongoing)
 
 == Changes in 9.0
 
 9.0 requires .ico files for favicons. This will change in 9.1, which
 will use .svg files. See
-xref:next@server:developer_manual:core/theming.adoc[Changing favicon] in the Developer Manual.
+xref:server:developer_manual:core/theming.adoc[Changing favicon] in the Developer Manual.
 
 Home folder rule is enforced in the user_ldap application in new
 ownCloud installations; see configuration/user/user_auth_ldap. This


### PR DESCRIPTION
Removes the last references to a `next` server version.

ownCloud Classic 11.0.0 is released, so docs-server master is renamed from the
`next` prerelease to `11.0` (owncloud/docs-server#1575) and no `next` server
version exists any more. Every `xref:next@server:` would then fail to resolve,
which is a build error, not a cosmetic problem.

## Changes

All in `modules/ROOT/pages/server_release_notes.adoc` — an org-wide code search
found `next@server` in no other repository.

* 8 xrefs → unversioned `xref:server:` (lines 1806, 1809, 1980–1982, 2039, 3620,
  3627). Unversioned resolves to whatever the component's latest version is, so
  these stay correct across future releases instead of needing another sweep.
* 1 hardcoded `https://doc.owncloud.com/server/next/admin_manual/…` URL (line
  1248) → `/server/latest/…`, for the same reason.

## Testing

Built the full site (`owncloud/docs`) with this branch and the docs-server PR
branches as sources: **0 errors, 0 warnings**, and all 9 links resolve. Without
this change the same build reports 9 unresolved xrefs.

Merge after owncloud/docs#5141.